### PR TITLE
Added SD-card reader functionality.

### DIFF
--- a/ulisp-tdeck.ino
+++ b/ulisp-tdeck.ino
@@ -4389,8 +4389,6 @@ object *fn_drawchar (object *args, object *env) {
       if (more != NULL) size = checkinteger(car(more));
     }
   }
-  //this drawchar doesnt take a size argument 
-  tft.setTextSize(size);
   tft.drawChar(checkinteger(first(args)), checkinteger(second(args)), checkchar(third(args)),
     colour, bg, size);
   #else
@@ -6174,7 +6172,6 @@ object *read (gfun_t gfun) {
 // Plot character at absolute character cell position
 void PlotChar (uint8_t ch, uint8_t line, uint8_t column) {
  #if defined(gfxsupport)
-  tft.setTextSize(1);
   uint16_t y = line*Leading;
   uint16_t x = column*6;
   uint8_t off = (ch & 0x80) ? 0x7 : 0;    // Parenthesis highlight

--- a/ulisp-tdeck.ino
+++ b/ulisp-tdeck.ino
@@ -6332,7 +6332,7 @@ void initBoard()
     SPI.begin(TDECK_SPI_SCK, TDECK_SPI_MISO, TDECK_SPI_MOSI); //SD
 }
 
-bool sd_begin(){
+void sd_begin(){
     digitalWrite(TDECK_SDCARD_CS, HIGH);
     digitalWrite(TDECK_LORA_CS, HIGH);
     digitalWrite(TDECK_TFT_CS, HIGH);


### PR DESCRIPTION
By pulling up the CS pins on all of the other SPI components and using a different tft library, I was able to get the SD card reader and the display to work together.  

The sd_begin function and initSD function are nearly identical, so they probably should be combined into one.  I was just not sure whether the Serial prints should be kept or removed.  I could see both use cases.